### PR TITLE
Attempt to convert client_auth_method to symbol

### DIFF
--- a/lib/rack/oauth2/client.rb
+++ b/lib/rack/oauth2/client.rb
@@ -76,7 +76,7 @@ module Rack
         #  Using Array#estract_options! for backward compatibility.
         #  Until v1.0.5, the first argument was 'client_auth_method' in scalar.
         options = args.extract_options!
-        client_auth_method = args.first || options.delete(:client_auth_method) || :basic
+        client_auth_method = args.first || options.delete(:client_auth_method).try(:to_sym) || :basic
 
         params[:scope] = Array(options.delete(:scope)).join(' ') if options[:scope].present?
         params.merge! options


### PR DESCRIPTION
Our configuration for OmniAuth strategies comes from a JSON file, which converts all symbols to strings. This change enables `client_auth_method` to be specified as string (e.g. `"basic"`, `"jwt_bearer"`, etc.).